### PR TITLE
Switch to ByteArrayJsonWriter for RESTEasy Reactive

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,10 +41,10 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus-plugin.version>1.11.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.11.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.11.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.11.1.Final</quarkus.platform.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <version.gpg.plugin>1.6</version.gpg.plugin>


### PR DESCRIPTION
During some profiling I did, I saw that the use
of OutputStreamJsonWriter was not ideal for
RESTEasy Reactive as it was leading to Netty buffers
one byte at a time