### PR TITLE
Switch to ByteArrayJsonWriter for RESTEasy Reactive

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,10 +41,10 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus-plugin.version>1.11.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>1.11.1.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>1.11.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>1.11.1.Final</quarkus.platform.version>
         <surefire-plugin.version>2.22.1</surefire-plugin.version>
         <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <version.gpg.plugin>1.6</version.gpg.plugin>

--- a/quarkus/resteasy-reactive-qson/runtime/src/main/java/io/quarkus/qson/resteasy/reactive/QsonMessageBodyWriter.java
+++ b/quarkus/resteasy-reactive-qson/runtime/src/main/java/io/quarkus/qson/resteasy/reactive/QsonMessageBodyWriter.java
@@ -1,6 +1,9 @@
 package io.quarkus.qson.resteasy.reactive;
 
 import io.quarkus.qson.resteasy.QsonResteasyUtil;
+import io.quarkus.qson.runtime.QuarkusQsonRegistry;
+import io.quarkus.qson.serializer.ByteArrayJsonWriter;
+import io.quarkus.qson.serializer.QsonObjectWriter;
 import org.jboss.resteasy.reactive.server.spi.ResteasyReactiveResourceInfo;
 import org.jboss.resteasy.reactive.server.spi.ServerMessageBodyWriter;
 import org.jboss.resteasy.reactive.server.spi.ServerRequestContext;
@@ -22,7 +25,9 @@ public class QsonMessageBodyWriter implements ServerMessageBodyWriter<Object> {
 
     @Override
     public void writeResponse(Object o, Type genericType, ServerRequestContext context) throws WebApplicationException, IOException {
-        QsonResteasyUtil.write(o, genericType, context.getOrCreateOutputStream());
+        OutputStream outputStream = context.getOrCreateOutputStream();
+        writeResponse(o, genericType, outputStream);
+        outputStream.close();
     }
 
     @Override
@@ -32,6 +37,17 @@ public class QsonMessageBodyWriter implements ServerMessageBodyWriter<Object> {
 
     @Override
     public void writeTo(Object o, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
-        QsonResteasyUtil.write(o, genericType, entityStream);
+        writeResponse(o, genericType, entityStream);
+    }
+
+    private void writeResponse(Object o, Type genericType, OutputStream outputStream) throws IOException {
+        QsonObjectWriter objectWriter = QuarkusQsonRegistry.getWriter(genericType);
+        if (objectWriter == null) {
+            throw new IOException("Failed to find QSON writer for: " + genericType.getTypeName());
+        }
+        ByteArrayJsonWriter jsonWriter = new ByteArrayJsonWriter();
+        objectWriter.write(jsonWriter, o);
+        outputStream.write(jsonWriter.getBuffer(), 0, jsonWriter.size());
+        outputStream.close();
     }
 }


### PR DESCRIPTION
During some profiling I did, I saw that the use
of OutputStreamJsonWriter was not ideal for
RESTEasy Reactive as it was leading to Netty buffers
one byte at a time

This is successor to #13 which I should not have closed as the idea was actually correct - the implementation in that PR had a small error that caused me to think it was invalid