### PR TITLE
Correct dead link in Guides section to point to readme

### DIFF
--- a/quarkus/extension/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/quarkus/extension/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -3,7 +3,7 @@ name: "QSON"
 metadata:
   keywords:
   - "json"
-  guide: "https://quarkus.io/guides/qson"
+  guide: "https://github.com/quarkusio/qson#readme"
   categories:
   - "serialization"
   status: "experimental"


### PR DESCRIPTION
The Quarkus extension metadata points to https://quarkus.io/guides/qson, which doesn't exist. I've put in https://github.com/quarkusio/qson as the best docs link I can find.